### PR TITLE
increase sort timeout to 1 hour

### DIFF
--- a/src/Keboola/S3Extractor/Finder.php
+++ b/src/Keboola/S3Extractor/Finder.php
@@ -129,7 +129,7 @@ class Finder
             $tmpFilePath,
         ];
         $env = ["LC_ALL" => "C"];
-        $process = new Process($args, null, $env)
+        $process = new Process($args, null, $env);
         $process->setTimeout(3600);
         $process->mustRun();
         return $sortedFilePath;

--- a/src/Keboola/S3Extractor/Finder.php
+++ b/src/Keboola/S3Extractor/Finder.php
@@ -129,7 +129,9 @@ class Finder
             $tmpFilePath,
         ];
         $env = ["LC_ALL" => "C"];
-        (new Process($args, null, $env))->mustRun();
+        $process = new Process($args, null, $env)
+        $process->setTimeout(3600);
+        $process->mustRun();
         return $sortedFilePath;
     }
 


### PR DESCRIPTION
Prislo zo zendesku: https://keboola.zendesk.com/agent/tickets/27974
Tato uprava nastavuje timeout php procesu ktory pusta `sort` z default 60 sekund na 1 hodinu, robil som to podla docs, tak snad to je cajk:
https://symfony.com/doc/current/components/process.html#process-timeout
Ide o to ze AWS ex spadol na tom ze po 60 sekundach vytimeoutoval sort 
![image](https://github.com/keboola/aws-s3-extractor/assets/1412120/42b78ec9-c0b2-4ab8-8031-796dcfcc7396)
https://app.datadoghq.eu/logs?query=pod_name%3Ajob-6586858%20&cols=host%2Cservice&event=AgAAAYgE81Puy3q1LAAAAAAAAAAYAAAAAEFZZ0U4MXlJQUFBVmtQZU1yR1hhM3dBTwAAACQAAAAAMDE4ODA1MDgtYTI1Ny00MDdlLTk3NDUtYjY4MzA1OTg0OTM4&index=%2A&messageDisplay=inline&saved-view-id=56457&stream_sort=desc&viz=stream&from_ts=1683625656228&to_ts=1683712056228&live=true
