### PR TITLE
feat: Skip files in S3 Glacier Deep Archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This component downloads files from S3 to `/data/out/files`.
 - Supports `*` wildcards
 - Handles subfolders
 - Can process only new files
-- Skips files stored in Glacier
+- Skips files stored in Glacier & Glacier Deep Archive
 
 ## Configuration Options
 

--- a/src/Keboola/S3Extractor/Finder.php
+++ b/src/Keboola/S3Extractor/Finder.php
@@ -317,6 +317,11 @@ class Finder
      */
     private function isFileIgnored(array $object): bool
     {
+        // Skip objects in Deep Archive
+        if ($object['StorageClass'] === "DEEP_ARCHIVE") {
+            return true;
+        }
+
         // Skip objects in Glacier
         if ($object['StorageClass'] === "GLACIER") {
             return true;


### PR DESCRIPTION
Skip Deep Archive Objects in S3 Extractor

🎯 Problem
The S3 Extractor was failing when encountering objects in DEEP_ARCHIVE storage class. 

📊 Impact
✅ Prevents failures when processing buckets with Deep Archive objects

🔍 Files Changed
src/Keboola/S3Extractor/Finder.php - Added Deep Archive skip logic
Type: Bug Fix / Enhancement
Breaking Change: No
Requires Documentation Update: No